### PR TITLE
feat(build): add support for importing graphql schema fragments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3923,6 +3923,22 @@
         "iterall": "^1.2.2"
       }
     },
+    "graphql-import": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
+      "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "chalk": "^2.4.2",
     "chokidar": "^2.1.6",
     "graphql": "^14.4.2",
+    "graphql-import": "^0.7.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "object-keys": "^1.1.1",

--- a/src/lib/http/gqlFunction.js
+++ b/src/lib/http/gqlFunction.js
@@ -1,39 +1,40 @@
-const { graphql, buildSchema } = require('graphql')
-const fs = require('fs')
-const { logger } = require('../utils')
+const { graphql } = require("graphql");
+const { importSchema } = require("graphql-import");
+const fs = require("fs");
+const { logger } = require("../utils");
 
 const handler = async (params, resolvers, schema, context) => {
   try {
-    const { query, variables } = params
+    const { query, variables } = params;
 
     if (!query) {
-      const response = 'No query specified'
-      logger('warn', `dev: ${response}`)
-      return response
+      const response = "No query specified";
+      logger("warn", `dev: ${response}`);
+      return response;
     } else {
-      const gqlSchema = await buildSchema(fs.readFileSync(schema, 'utf-8'))
-      const resolverModule = require(resolvers)
+      const gqlSchema = await importSchema(schema, "utf-8");
+      const resolverModule = require(resolvers);
       const response = await graphql(
         gqlSchema,
         query,
         resolverModule,
         context,
         variables
-      )
+      );
       if (response.errors) {
         logger(
-          'warn',
+          "warn",
           `query error response:\n${JSON.stringify(response, null, 2)}`
-        )
+        );
       }
-      return JSON.stringify(response)
+      return JSON.stringify(response);
     }
   } catch (error) {
-    logger('error', `Unable to process GraphQL Query with error:\n${error}`)
+    logger("error", `Unable to process GraphQL Query with error:\n${error}`);
     return {
       error
-    }
+    };
   }
-}
+};
 
-export default handler
+export default handler;

--- a/src/lib/http/gqlFunction.mjs
+++ b/src/lib/http/gqlFunction.mjs
@@ -1,24 +1,24 @@
-import { graphql, buildSchema } from 'graphql'
-import { readFileSync } from 'fs'
-import { logger } from '../utils'
+import { graphql } from "graphql";
+import { importSchema } from "graphql-import";
+import { logger } from "../utils";
 // import resolverFunc from '../../test/sample/resolvers'
 
 const handler = async (params, resolvers, schema, context) => {
   try {
-    const { query, variables } = params
+    const { query, variables } = params;
 
     if (!query) {
-      const response = 'No query specified'
-      logger('warn', `dev: ${response}`)
-      return response
+      const response = "No query specified";
+      logger("warn", `dev: ${response}`);
+      return response;
     } else {
-      logger('warn', `resolvers: ${resolvers}\nschema:${schema}`)
+      logger("warn", `resolvers: ${resolvers}\nschema:${schema}`);
       // logger('warn', `query: ${query}\nvariables:${variables}`)
-      const gqlSchema = await buildSchema(readFileSync(schema, 'utf-8'))
+      const gqlSchema = await importSchema(schema, "utf-8");
 
-      const importedModule = await import(resolvers)
+      const importedModule = await import(resolvers);
 
-      const resolverModule = importedModule.default
+      const resolverModule = importedModule.default;
 
       const response = await graphql(
         gqlSchema,
@@ -26,21 +26,21 @@ const handler = async (params, resolvers, schema, context) => {
         resolverModule,
         context,
         variables
-      )
+      );
       if (response.errors) {
         logger(
-          'warn',
+          "warn",
           `query error response:\n${JSON.stringify(response, null, 2)}`
-        )
+        );
       }
-      return JSON.stringify(response)
+      return JSON.stringify(response);
     }
   } catch (error) {
-    logger('error', `Unable to process GraphQL Query with error:\n${error}`)
+    logger("error", `Unable to process GraphQL Query with error:\n${error}`);
     return {
       error
-    }
+    };
   }
-}
+};
 
-export default handler
+export default handler;

--- a/test/sample/schema/episodes.gql
+++ b/test/sample/schema/episodes.gql
@@ -1,0 +1,10 @@
+enum Episode {
+  PHANTOM
+  CLONES
+  SITH
+  NEWHOPE
+  EMPIRE
+  JEDI
+  FORCE
+  LASTJEDI
+}

--- a/test/sample/schema/starwars.gql
+++ b/test/sample/schema/starwars.gql
@@ -1,3 +1,5 @@
+# import Episode from "episodes.gql"
+
 type Query {
   human(id: ID!): Human
   allHumans: [Human]
@@ -11,17 +13,6 @@ interface Character {
   friends: [Character]
   appearsIn: [Episode]
   secretBackstory: String
-}
-
-enum Episode {
-  PHANTOM
-  CLONES
-  SITH
-  NEWHOPE
-  EMPIRE
-  JEDI
-  FORCE
-  LASTJEDI
 }
 
 type Droid implements Character {


### PR DESCRIPTION
Use https://github.com/prisma/graphql-import to make it possible to import schema fragments, which is useful when working with expansive schemas or third-party schemas that are used as delegation targets

---

I haven't tested this yet – at least I believe the current tests don't cover the actual building and execution of the sample function, so take it with a pinch of salt. Also, sorry for the reformatting, I believe it's the `"editor.formatOnSave": true,` setting for VSCode that is checked in for the workspace.